### PR TITLE
amami - October 2021 update

### DIFF
--- a/amami.json
+++ b/amami.json
@@ -1,12 +1,12 @@
 {
   "response": [
     {
-      "datetime": "1632153828",
-      "filename": "lineage-18.1-20210920-UNOFFICIAL-amami-signed.zip",
-      "id": "ea3e7231502246581d917ccc4bad8d97",
+      "datetime": "1634160569",
+      "filename": "lineage-18.1-20211013-UNOFFICIAL-amami-signed.zip",
+      "id": "63581ccbb68d5e76e3cbbf51819c053c3b17052b",
       "romtype": "UNOFFICIAL",
-      "size": "531538357",
-      "url": "https://sourceforge.net/projects/lin18/files/amami/LineageOS_18_signed/lineage-18.1-20210920-UNOFFICIAL-amami-signed.zip/download",
+      "size": "533206572",
+      "url": "https://sourceforge.net/projects/lin18/files/amami/LineageOS_18_signed/lineage-18.1-20211013-UNOFFICIAL-amami-signed.zip/download",
       "version": "18.1"
     }
   ]


### PR DESCRIPTION
This PR will update a very last time the static resource in github.com/115ek, as your previous "regular builds" expect the .json resource exactly there for the build type 'UNOFFICIAL'.
The October build variant A will point to github.com/lin18-microG/OTA and build-type 'UNOFFICIAL-signed'
Cheers, M.